### PR TITLE
gitIgnore addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ yarn-error.log*
 # Optional eslint cache
 .eslintcache
 
-# dotenv environment variables file
+# dotenv environment variables file(s)
 .env
+.env.*
 
 #Build generated
 dist/


### PR DESCRIPTION
support multiple .env files - use of which are described in the Environments section.