### PR TITLE
Basic auth on HTTPS is OK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ The **client app did something wrong** or The **API did something wrong**.
 ### 9.2 API security
 These are some basic security best practices:
 
-* Don't use basic authentication. Authentication tokens must not be transmitted in the URL: `GET /users/123?token=asdf....`
+* Don't use basic authentication unless over a secure connection (HTTPS). Authentication tokens must not be transmitted in the URL: `GET /users/123?token=asdf....`
 
     _Why:_
     > Because Token, or user ID and password are passed over the network as clear text (it is base64 encoded, but base64 is a reversible encoding), the basic authentication scheme is not secure. [read more...](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)


### PR DESCRIPTION
From the MDN article, it's advised to avoid basic auth if on HTTP, otherwise it can be used.