### PR TITLE
Add Vim swap files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ build/
 !.vscode/launch.json
 !.vscode/extensions.json
 
+### Vim ###
+*.sw[a-p]
+
 ### WebStorm/IntelliJ ###
 /.idea
 modules.xml


### PR DESCRIPTION
Vim creates swap files when open buffers are edited.

These files preserve un-written changes in buffers. They are useful for
recovering from system crashes, preventing multiple write-buffers on a
single file (which could cause "phantom-edits"), etc.

However, these swap files should not be tracked in a git repository.

For a given working file, Vim will create a swap file of the format
`<filename>.swp`.

Vim will attempt to remove swap files upon writing & exiting Vim.
However, swap files aren't always cleaned up. This may happen if Vim
terminates improperly due to a system crash or similar.

So, if Vim attempts to create a swap file of the format
`<filename>.swp`, but that path already exists, then Vim will create a
swap file of the format `<filename>.swo`.

If `<filename>.swo` already exists, then Vim will create a swap file
`<filename>.swn`.

Vim will continue backwards through the alphabet until it finds an
available swap-file path.

If `<filename>.sw[a-p]` is completely occupied, then Vim will attempt
`<filename>.sv[a-z]`, and so forth.

However, I did not include `*.sv[a-z]` in this change because I believe
that would be overkill, and it may trespass on other programs.

I am reasonably certain that no other programs rely on `*.sw[a-p]`
files. I am less certain about `*.sv[a-z]` files.

Also, having that many swap files is a rarity. The disadvantages of
including `*.sv[a-z]` in the .gitignore outweigh the benefits.

So, I only included `*.sw[a-p]` files in this change.