### PR TITLE
Update .gitignore to cover all .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ modules.xml
 
 
 ### System Files ###
-.DS_Store
+*.DS_Store
 
 # Windows thumbnail cache files
 Thumbs.db


### PR DESCRIPTION
.DS_Store files tend to pop up in subfolders too - added * pattern to ignore any that appear in subfolders rather than just the root dir.