### PR TITLE
Fix Japanese translation of "imperative mood"

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -161,7 +161,7 @@
 
  * 主題の先頭は大文字にしましょう。
  * ピリオドで終わるのをやめましょう。
- * 主題部分では[仮定法](https://en.wikipedia.org/wiki/Imperative_mood) を使いましょう。
+ * 主題部分では[命令法](https://en.wikipedia.org/wiki/Imperative_mood) を使いましょう。
 
     _Why:_
     > コミッタが何を行ったかわかりやすいメッセージを書きましょう。コミットがマージされた後にそのコミットが何をしたのかをうまく説明できるように考えるといいでしょう。[もっと読む...](https://news.ycombinator.com/item?id=2079612)


### PR DESCRIPTION
The word "imperative mood" (Meireiho; 命令法) in the source language was translated as "subjunctive mood"(Kateiho; 仮定法) in Japanese by mistake. Both moods is different in English linguistics. The translation should be fixed.