### PR TITLE
Adds 204 status code as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,13 +643,15 @@ _Why:_
 
     _Note: Keep security exception messages as generic as possible. For instance, Instead of saying ‘incorrect password’, you can reply back saying ‘invalid username or password’ so that we don’t unknowingly inform user that username was indeed correct and only the password was incorrect._
 
-* Use only these 8 status codes to send with you response to describe whether **everything worked**,
+* Use these status codes to send with you response to describe whether **everything worked**,
 The **client app did something wrong** or The **API did something wrong**.
     
     _Which ones:_
     > `200 OK` response represents success for `GET`, `PUT` or `POST` requests.
 
     > `201 Created` for when a new instance is created. Creating a new instance, using `POST` method returns `201` status code.
+
+    > `204 No Content` response represents success but there is no content to be sent in the response. Use it when `DELETE` operation succeeds.
 
     > `304 Not Modified` response is to minimize information transfer when the recipient already has cached representations.
 

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ _Why:_
 
     _Note: Keep security exception messages as generic as possible. For instance, Instead of saying ‘incorrect password’, you can reply back saying ‘invalid username or password’ so that we don’t unknowingly inform user that username was indeed correct and only the password was incorrect._
 
-* Use these status codes to send with you response to describe whether **everything worked**,
+* Use these status codes to send with your response to describe whether **everything worked**,
 The **client app did something wrong** or The **API did something wrong**.
     
     _Which ones:_


### PR DESCRIPTION
I've decided to add `204 No Content` to the list of status codes to use. As it already describes `201 Created` for creating a new resource, I think `204 No Content` for deletion won't make any harmness.

It is a bit strange to respond with `200 OK` with no body response or even a ``{success: true}`` or similar when deleting a resource, that is why I'm in favor of `204 No Content` in this case.

So instead of updating to ``Use only these 9 status...`` I changed to ``Use these status...``