### PR TITLE
Add badges for the README sample file

### DIFF
--- a/README.sample.md
+++ b/README.sample.md
@@ -1,6 +1,6 @@
 ![Logo of the project](./images/logo.sample.png)
 
-# Name of the project
+# Name of the project &middot; [![Build Status](https://img.shields.io/travis/npm/npm/latest.svg?style=flat-square)](https://travis-ci.org/npm/npm) [![npm](https://img.shields.io/npm/v/npm.svg?style=flat-square)](https://www.npmjs.com/package/npm) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/your/your-project/blob/master/LICENSE)
 > Additional information or tag line
 
 A brief description of your project, what it is used for.


### PR DESCRIPTION
I think that every project worth to put on badges to show vital info at first glance. And it will also become more friendly for users in visual.

So I added four types of badges:
1. **Build Status** - To indicate the health of latest build
2. **NPM Package version** - To display the newest version of the package. Often be useful for people who are maintaining a JavaScript library.
3. **PRs Welcome** - To make the repository more friendly for other contributors.
4. **License** - To indicate the LICENSE we used.

-----

Here is how it looks like after adding badges
<img width="689" alt="osx 2018-02-25 at 3 45 57 pm" src="https://user-images.githubusercontent.com/7029623/36639233-09d48898-1a43-11e8-867c-143e4b07eda4.png">
