### PR TITLE
add branch naming conventions rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ There are a set of rules to keep in mind:
 
   > Because this way all work is done in isolation on a dedicated branch rather than the main branch. It allows you to submit multiple pull requests without confusion. You can iterate without polluting the master branch with potentially unstable, unfinished code. [read more...](https://www.atlassian.com/git/tutorials/comparing-workflows#feature-branch-workflow)
 
+- Name your feature branches consistently. Agree with your team on a naming convention such as `feat/[task-id]/descriptive-text`.
+
+  _Why:_
+
+  > Having a consistent naming convention helps communicate needed information across the team and keep branches organized.
+
 - Branch out from `develop`
 
   _Why:_


### PR DESCRIPTION
Add a branch naming convention rule to encourage organization and consistency in feature branch names.

I've found this very useful working in teams, both to help teammates stay organized when thinking about how many `chunks` to break a TODO into  like:

`[type]/[task-id]/descriptive-text`

```
feat/1234/datatable-ui-layer
feat/1234/datatable-api-logic
etc....
```

and also to help communicate to each other and to PMs what a branch is for, even weeks later ;)